### PR TITLE
Adding homebrew action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,6 +32,10 @@ jobs:
 
       - name: Setup asdf
         uses: asdf-vm/actions/setup@v1
+        
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install bats-core
         run: brew install bats-core
@@ -49,6 +53,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install ShellCheck
         run: brew install shellcheck
@@ -62,6 +70,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install shfmt
         run: brew update && brew install shfmt


### PR DESCRIPTION
Runner images updated remove homebrew. Has been recommended in this issue if homebrew is needed in the build to use the action: https://github.com/actions/runner-images/issues/6283. Should fix the main workflow