### PR TITLE
Setup poetry autocompletion

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -62,6 +62,23 @@ install_poetry() {
     echo Consider upgrading to a later version.
     echo https://github.com/asdf-community/asdf-poetry/issues/10
   fi
+
+  if [ $config_vercomp == "ge" ]; then
+    if [ -n "${BASH_VERSION:-}" ]; then
+      "$install_path"/bin/poetry completions bash >>~/.bash_completion
+    elif [ -n "${ZSH_VERSION:-}" ]; then
+      "$install_path"/bin/poetry completions zsh >~/.zfunc/_poetry
+      echo "fpath+=~/.zfunc" >>~/.zshrc
+      echo "autoload -Uz compinit && compinit" >>~/.zshrc
+    elif [ -n "${FISH_VERSION:-}" ]; then
+      "$install_path"/bin/poetry completions fish >~/.config/fish/completions/poetry.fish
+    else
+      echo "Warning: Could not detect BASH, ZSH or FISH."
+      echo "Could not complete autocompletion setup"
+    fi
+  else
+    echo "Warning: Poetry versions prior to 1.2.0 will not have autocompletion"
+  fi
 }
 
 install_poetry "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"


### PR DESCRIPTION
Sets up poetry autocompletion by detecting the shell running. Based on documentation on Poetry website: https://python-poetry.org/docs/#enable-tab-completion-for-bash-fish-or-zsh